### PR TITLE
👷 use --link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.4.0
 FROM alpine:3
 
 LABEL org.opencontainers.image.source https://github.com/chorrell/docker-httpie
@@ -5,7 +6,7 @@ LABEL org.opencontainers.image.source https://github.com/chorrell/docker-httpie
 RUN set -ex \
     && apk add --no-cache py3-setuptools httpie
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY --link docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 


### PR DESCRIPTION
See:

https://www.docker.com/blog/image-rebase-and-improved-remote-cache-support-in-new-buildkit/