### PR TITLE
ci: add pre-commit hooks and resolve all linting issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "monday"
       time: "09:30"
       timezone: "America/Toronto"
+    cooldown:
+      default-days: 7
     pull-request-branch-name:
       separator: "/"
     commit-message:
@@ -20,6 +22,8 @@ updates:
       day: "monday"
       time: "09:45"
       timezone: "America/Toronto"
+    cooldown:
+      default-days: 7
     pull-request-branch-name:
       separator: "/"
     commit-message:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,12 +20,12 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           load: true
@@ -47,38 +47,38 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           flavor: latest=true
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}, ghcr.io/chorrell/${{ env.IMAGE_NAME }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
       - name: Build and push
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,8 @@ on:
 
   pull_request:
 
+permissions: {}
+
 env:
   IMAGE_NAME: http
 
@@ -14,18 +16,23 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           load: true
           tags: ${{ env.IMAGE_NAME }}
-      
+
       - name: Test
-        run: docker run -i --rm $IMAGE_NAME --version
+        run: docker run -i --rm "$IMAGE_NAME" --version
 
   # Push image to GitHub Container Registry
   # See also https://docs.docker.com/docker-hub/builds/
@@ -36,37 +43,42 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 
+    permissions:
+      contents: read
+
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           flavor: latest=true
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}, ghcr.io/chorrell/${{ env.IMAGE_NAME }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,16 +3,26 @@ name: Check Shell scripts
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   shfmt:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - run: docker run --rm -v "$(pwd)":/sh -w /sh mvdan/shfmt:v3.1.1 -sr -i 2 -l -w -ci .
       - run: git diff --color --exit-code
 
   shellcheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      - run: shellcheck *.sh
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - run: shellcheck ./*.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - run: docker run --rm -v "$(pwd)":/sh -w /sh mvdan/shfmt:v3.1.1 -sr -i 2 -l -w -ci .
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - run: shellcheck ./*.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,48 @@
+repos:
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.14.0
+    hooks:
+      - id: hadolint-docker
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.22.1
+    hooks:
+      - id: markdownlint-cli2-docker
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+      - id: mixed-line-ending
+
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
+    hooks:
+      - id: shfmt-docker
+        args: [-sr, -i, '2', -w, -ci]
+        files: \.(sh|bats)$
+
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.11.0
+    hooks:
+      - id: shellcheck
+        files: \.(sh|bats)$
+
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.25.2
+    hooks:
+      - id: zizmor

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3
 
 LABEL org.opencontainers.image.source=https://github.com/chorrell/docker-httpie
 
+# hadolint ignore=DL3018
 RUN set -ex \
     && apk add --no-cache py3-setuptools httpie
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ alias http='docker run -i --rm http'
 
 ## Using the Docker Hub image
 
-The lateset version of this image is published to the Docker Hub. You can use it like this:
+The lateset version of this image is published to the Docker Hub. You can use
+it like this:
 
 ```sh
 docker pull chorrell/http:latest
@@ -66,7 +67,8 @@ alias http='docker run -i --rm ghcr.io/chorrell/http:latest'
 
 ## Using the GitHub Container Registry image
 
-The lateset version of this image is published to the GitHub Container Registry. You can use it like this:
+The lateset version of this image is published to the GitHub Container
+Registry. You can use it like this:
 
 ```sh
 docker pull ghcr.io/chorrell/http:latest


### PR DESCRIPTION
## Summary

- Adds `.pre-commit-config.yaml` with 8 hooks: actionlint, gitleaks, hadolint, markdownlint-cli2, standard pre-commit-hooks (trailing whitespace, EOF, YAML, merge conflict, large files, line endings), shfmt, shellcheck, and zizmor
- Resolves every finding surfaced by those hooks across the existing codebase

## Changes

**New file**
- `.pre-commit-config.yaml` — full hook suite for CI quality gates

**Existing files fixed to pass all hooks**
- Pin all GitHub Actions `uses:` references to commit SHAs with version comments (zizmor `unpinned-uses`)
- Add `permissions: {}` at workflow level + `contents: read` per job (zizmor `excessive-permissions`)
- Add `persist-credentials: false` to all `actions/checkout` steps (zizmor `artipacked`)
- Add `cooldown: default-days: 7` to both Dependabot ecosystems (zizmor `dependabot-cooldown`)
- Quote `"$IMAGE_NAME"` in `docker run` command (actionlint / shellcheck SC2086)
- Fix shellcheck glob: `*.sh` → `./*.sh` (actionlint / shellcheck SC2035)
- Add `# hadolint ignore=DL3018` for unpinned `apk add` packages (hadolint DL3018)
- Wrap two README lines exceeding 80 characters (markdownlint MD013)

## Test plan

- [x] `pre-commit run --all-files` passes all 13 hooks locally with zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)