### PR TITLE
ci: set dependabot update interval to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:30"
-      timezone: "America/Toronto"
+      interval: "daily"
     cooldown:
       default-days: 7
     pull-request-branch-name:
@@ -18,10 +15,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:45"
-      timezone: "America/Toronto"
+      interval: "daily"
     cooldown:
       default-days: 7
     pull-request-branch-name:


### PR DESCRIPTION
## Summary

- Changes the Dependabot schedule interval from `weekly` to `daily` for both the `github-actions` and `docker` package ecosystems

🤖 Generated with [Claude Code](https://claude.com/claude-code)